### PR TITLE
Fix warn deprecation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,0 @@
-<!DOCTYPE html>
-<html>
-  <body>
-    <h1>Package index</h1>
-    <div class="package" >
-      <a href="patient-similarity/">patient_similarity</a>
-    </div>
-  </body>
-</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <h1>Package index</h1>
+    <div class="package" >
+      <a href="patient-similarity/">patient_similarity</a>
+    </div>
+  </body>
+</html>

--- a/patient_similarity/disease.py
+++ b/patient_similarity/disease.py
@@ -139,7 +139,7 @@ class Diseases:
                             phenotypes[hp_term] = freq
 
                         if old_freq != freq:
-                            logging.warn('Found conflicting frequencies ({}, {}) for same disease-phenotype: {}:{} - {} (taking larger)'.format(old_freq, freq, disease[0], disease[1], hp_term))
+                            logging.warning('Found conflicting frequencies ({}, {}) for same disease-phenotype: {}:{} - {} (taking larger)'.format(old_freq, freq, disease[0], disease[1], hp_term))
                     else:
                         phenotypes[hp_term] = freq
 

--- a/patient_similarity/hpoic.py
+++ b/patient_similarity/hpoic.py
@@ -96,10 +96,10 @@ class HPOIC:
                 raw_freq[term] += freq * prevalence
 
         if use_phenotype_frequency:
-            logging.warn('Used phenotype frequencies for {}/{} disease-phenotype associations'.format(n_phenotype_freqs_used, n_entries))
+            logging.warning('Used phenotype frequencies for {}/{} disease-phenotype associations'.format(n_phenotype_freqs_used, n_entries))
 
         if use_disease_prevalence:
-            logging.warn('Used disease prevalences for {}/{} diseases'.format(n_disease_prevalences_used, len(diseases)))
+            logging.warning('Used disease prevalences for {}/{} diseases'.format(n_disease_prevalences_used, len(diseases)))
 
         if patients:
             for patient in patients:
@@ -107,7 +107,7 @@ class HPOIC:
                     raw_freq[term] += 1
 
         if distribute_ic_to_leaves:
-            logger.warn('DISTRIBUTING WEIGHT TO LEAVES')
+            logger.warning('DISTRIBUTING WEIGHT TO LEAVES')
             q = [hpo.root]
 
             while q:


### PR DESCRIPTION
Hi! I'm using your package to compute phenotype similarities. It works great! :)
But there's an annoying deprecation warning. This should fix it!

Fix "DeprecationWarning: The 'warn' function is deprecated, use 'warning' instead" messages